### PR TITLE
added os check for windows 10 cmd colour fix.

### DIFF
--- a/mov_cli/main.py
+++ b/mov_cli/main.py
@@ -15,7 +15,9 @@ calls = {
     'solar': Solar
 }
 
-os.system('color FF') # Fixes colour in Windows 10 CMD terminal.
+# Fixes colour in Windows 10 CMD terminal.
+if sys.platform == "win32":
+    os.system('color FF') 
 
 @click.command()
     # @click.option('--name', prompt='The name of the movie/series with the provider',

--- a/mov_cli/main.py
+++ b/mov_cli/main.py
@@ -17,7 +17,7 @@ calls = {
 
 # Fixes colour in Windows 10 CMD terminal.
 if sys.platform == "win32":
-    os.system('color FF') 
+    os.system('color FF')
 
 @click.command()
     # @click.option('--name', prompt='The name of the movie/series with the provider',


### PR DESCRIPTION
Adding onto #8 like said I said here https://github.com/mov-cli/mov-cli/pull/8#issuecomment-1127650184

This removes the `sh: 1: color: not found` message when running on linux.

