### PR TITLE
added linux section to readme mentioning pycryptodone

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@
       <li><a href="#installation">Installation</a></li>
       <ul>
         <li><a href="#win-and-linux">Windows / Linux</a></li>
+        <ul>
+          <li><a href="#linux">Linux</a></li>
+        </ul>
         <li><a href="#android">Android</a></li>
       </ul>
     </ul>

--- a/README.md
+++ b/README.md
@@ -103,7 +103,12 @@ Actvid · SFlix · Solar · DopeBox · WLEXT · KinoX · StreamBlasters · Tamil
 
 ### Windows / Linux
     pip install mov-cli
-   
+<!-- LINUX -->
+### Linux
+  - If the above command results in an error, install `pycryptodome` before installing mov-cli.
+    ```
+    pip install pycryptodome
+    ```
 <!-- ANDROID -->
 ### Android
   - Make sure [MPV](https://play.google.com/store/apps/details?id=is.xyz.mpv) and [Termux](https://play.google.com/store/apps/details?id=com.termux) from Play Store is installed.


### PR DESCRIPTION
I added the part about installing pycryptodome to a brief linux subsection in the installation section of the readme.  Might make more sense to instead make a troubleshooting section in the reame or to create a seperate TROUBLESHOOTING.md file where more stuff like this can be added.