### PR TITLE
fix: 'kisscartoon' last page indexing

### DIFF
--- a/mov_cli/websites/kisscartoon.py
+++ b/mov_cli/websites/kisscartoon.py
@@ -35,7 +35,8 @@ class kisscartoon(WebScraper):
             "p"
         ]
         print(season_id)
-        last_page = soup.select("ul.episode_list > li")[-1].text
+        try: last_page = soup.select("ul.episode_list > li")[-1].text
+        except IndexError: last_page = 0
         self.client.add_elem({"referer": url})
         self.client.add_elem({"x-requested-with": "XMLHttpRequest"})
         num_eps = BS(

--- a/mov_cli/websites/kisscartoon.py
+++ b/mov_cli/websites/kisscartoon.py
@@ -35,8 +35,10 @@ class kisscartoon(WebScraper):
             "p"
         ]
         print(season_id)
-        try: last_page = soup.select("ul.episode_list > li")[-1].text
-        except IndexError: last_page = 0
+        try:
+            last_page = soup.select("ul.episode_list > li")[-1].text
+        except IndexError:
+            last_page = 0
         self.client.add_elem({"referer": url})
         self.client.add_elem({"x-requested-with": "XMLHttpRequest"})
         num_eps = BS(


### PR DESCRIPTION
Was trying to watch Spongebob Season 1 with KissCartoon when IndexError exception showed up.
```
[!] What would you like to watch: Spongebob
https://thekisscartoon.com/?s=Spongebob
12227
Traceback (most recent call last):
  File ".../mov-cli/runner.py", line 4, in <module>
    movcli()
  File ".../mov-cli/mov_cli/__main__.py", line 63, in movcli
    provider.redo()  # if result else provider.redo(query)
  File ".../mov-cli/mov_cli/utils/scraper.py", line 249, in redo
    return self.display(search, result)
  File ".../mov-cli/mov_cli/utils/scraper.py", line 240, in display
    self.TV_PandDP(mov_or_tv, "p")
  File ".../mov-cli/mov_cli/websites/kisscartoon.py", line 86, in TV_PandDP
    link, episode = self.ask(t[self.url])
  File ".../mov-cli/mov_cli/websites/kisscartoon.py", line 38, in ask
    last_page = soup.select("ul.episode_list > li")[-1].text
IndexError: list index out of range

```

- [x] Now uses try/catch statements to set last_page to 0 if last index is not applicable for KissCartoon.
- [x] Can now watch Spongebob Season 1! :+1: :smile: 