### PR TITLE
added support for flatpak mpv via --flatpak-mpv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 dist/*
 build/*
 mov_cli.egg-info/*
+env

--- a/mov_cli/__init__.py
+++ b/mov_cli/__init__.py
@@ -1,0 +1,7 @@
+import argparse
+
+args_parser = argparse.ArgumentParser()
+args_parser.add_argument("--flatpak-mpv", action = argparse.BooleanOptionalAction)
+
+CMD_ARGS = args_parser.parse_args()
+"""Arguments parsed from the command line via argparse."""

--- a/mov_cli/__main__.py
+++ b/mov_cli/__main__.py
@@ -53,7 +53,6 @@ calls = {
 if platform.system() == "Windows":
     os.system("color FF")  # Fixes colour in Windows 10 CMD terminal
 
-
 def movcli():  # TODO add regex
     try:
         provider = ask()

--- a/mov_cli/players/player.py
+++ b/mov_cli/players/player.py
@@ -1,8 +1,7 @@
 import sys
 import subprocess
-import time
 
-
+from .. import CMD_ARGS
 from ..utils.player import Player, PlayerNotFound
 
 
@@ -40,14 +39,20 @@ class ply(Player):
         else:  # Windows, Linux and Other
             try:
                 if self.os == "Linux" or self.os == "Windows":
+                    mpv_args = [
+                        f"--referrer={referrer}",
+                        f"{url}",
+                        f"--force-media-title=mov-cli:{media_title}",
+                        "--no-terminal",
+                    ]
+
+                    if CMD_ARGS.flatpak_mpv and self.os == "Linux": # Support for MPV on flatpak.
+                        return subprocess.Popen(
+                            ["flatpak", "run", "io.mpv.Mpv/x86_64/stable"] + mpv_args
+                        )
+
                     return subprocess.Popen(
-                        [
-                            "mpv",
-                            f"--referrer={referrer}",
-                            f"{url}",
-                            f"--force-media-title=mov-cli:{media_title}",
-                            "--no-terminal",
-                        ]
+                        ["mpv"] + mpv_args
                     )
 
                 elif self.os == "Darwin":

--- a/mov_cli/players/player.py
+++ b/mov_cli/players/player.py
@@ -46,9 +46,10 @@ class ply(Player):
                         "--no-terminal",
                     ]
 
-                    if CMD_ARGS.flatpak_mpv and self.os == "Linux": # Support for MPV on flatpak.
+                    if CMD_ARGS.flatpak_mpv and self.os == "Linux": # Support for MPV on Flatpak.
+                        print("Using flatpak installation of MPV.")
                         return subprocess.Popen(
-                            ["flatpak", "run", "io.mpv.Mpv/x86_64/stable"] + mpv_args
+                            ["flatpak", "run", "io.mpv.Mpv"] + mpv_args
                         )
 
                     return subprocess.Popen(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mov-cli"
-version = "1.4.1"
+version = "1.4.2"
 description = "A cli tool to browse and watch Movies/Shows/TV/Sports."
 authors = ["Pain <painedposeidon444@gmail.com>"]
 maintainers = ["Ananas <ananas@historylifeonline.xyz>"]


### PR DESCRIPTION
Hi, I would like to add support for MPV via Flatpak because of the issues I've been having with the typical installation methods.

I've been having playback issues with the mpv on Fedora ever since I switched to Linux, I've tried to debug it but I'm yet to find out the cause but the Flatpak version of MPV seems to have no problem streaming whatsoever so I was forced to use it.

**The issue:**
The flatpak version of MPV doesn't come with the `mpv` alias, you instead need to do `flatpak run io.mpv.Mpv` to launch mpv which is why `mov-cli` fails without this implementation.

**How to use:**
```shell
mov-cli --flatpak-mpv
```
With this flag, mov-cli will use the flatpak installation of mpv instead of the typical installation.