### PR TITLE
feat: add custom scraper args to cli #255 #249

### DIFF
--- a/mov_cli/__init__.py
+++ b/mov_cli/__init__.py
@@ -5,4 +5,4 @@ from .config import *
 from .scraper import *
 from .download import *
 
-__version__ = "4.1.3"
+__version__ = "4.1.4"

--- a/mov_cli/cli/__main__.py
+++ b/mov_cli/cli/__main__.py
@@ -61,7 +61,12 @@ def mov_cli(
         utils.open_config_file(config)
 
     if len(query) > 0:
+        scrape_arguments = utils.steal_scraper_args(query) 
+        # This allows passing arguments to scrapers like this: 
+        # https://github.com/mov-cli/mov-cli-youtube/commit/b538d82745a743cd74a02530d6a3d476cd60b808#diff-4e5b064838aa74a5375265f4dfbd94024b655ee24a191290aacd3673abed921a
+
         query: str = " ".join(query)
+
         http_client = HTTPClient(config)
 
         chosen_scraper = select_scraper(config.plugins, config.fzf_enabled, config.default_scraper)
@@ -109,7 +114,7 @@ def mov_cli(
             return False
 
         mov_cli_logger.info(f"Scrapping media for '{Colours.CLAY.apply(choice.title)}'...")
-        media = scraper.scrape(choice, episode)
+        media = scraper.scrape(choice, episode, **scrape_arguments)
 
         if download:
             dl = Download(config)

--- a/mov_cli/cli/utils.py
+++ b/mov_cli/cli/utils.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     import logging
-    from typing import Literal, Optional, Any
+    from typing import Literal, Optional, Any, List, Dict
     from ..media import Metadata
     from ..scraper import Scraper
     from ..config import Config
@@ -27,7 +27,8 @@ __all__ = (
     "welcome_msg", 
     "handle_episode", 
     "set_cli_config", 
-    "open_config_file"
+    "open_config_file",
+    "steal_scraper_args"
 )
 
 def greetings() -> Literal["Good Morning", "Good Afternoon", "Good Evening", "Good Night"]:
@@ -183,3 +184,15 @@ def open_config_file(config: Config):
             editor = "nano"
 
     os.system(f"{editor} {config.config_path}")
+
+def steal_scraper_args(query: List[str]) -> Dict[str, bool]:
+    scrape_arguments = [x for x in query if "--" in x]
+
+    mov_cli_logger.debug(f"Scraper args picked up on --> {scrape_arguments}")
+
+    for scrape_arg in scrape_arguments:
+        query.remove(scrape_arg)
+
+    return dict(
+        [(x.replace("--", ""), True) for x in scrape_arguments]
+    )


### PR DESCRIPTION
This is the pull request that will break plugins that have not performed the changes stated at #255. I'll hold back on this pull request for a little while.

This feature allows the passing of arguments directly to the scraper. Like example let's say I want to stream the song "82 99 F.M" from "macross 82-99" on youtube, but I want audio only; thanks to scraper args we can actually tell the scraper that we would like to scrape the audio stream instead of the video stream like so:
```sh
mov-cli -c 1 -s youtube 82 99 F.M macross 82-99 -- --audio
```

``--`` is the magic here, ``--`` tells the cli that the arguments after it should be passed directly to the scraper. You can take advantage of this in the `Scraper.scrape()` method like so:
```python
def scrape(self, metadata: Metadata, episode: Optional[utils.EpisodeSelector] = None, **kwargs: Dict[str, bool]) -> Series | Movie:
    audio_only: bool = kwargs.get("audio", False)

    print(f"Audio mode is '{audio_only}'!")
```