### PR TITLE
Add clarification about where the config file is stored in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,8 @@ Alternatively, you may also edit by manually opening the config file in:
 
 - **Windows:** `%LocalAppData%/mov-cli/config.toml`
 - **macOS:** `~/Library/Application Support/mov-cli/config.toml`
-- **Linux:** `~/.config/mov-cli/config.toml`
+- **Linux/Android:** `~/.config/mov-cli/config.toml`
 - **iOS:** `~/Library/mov-cli/config.toml`
-- **Android:** `~/.config/mov-cli/config.toml`
   
 ```toml
 [mov-cli.plugins]

--- a/README.md
+++ b/README.md
@@ -63,10 +63,16 @@ mov-cli comes packaged with a CLI interface via the `mov-cli` command you can us
 ```sh
 mov-cli -e
 ```
+Alternatively, you may also edit by manually opening the config file in:
+
+- **Windows:** `%LocalAppData%/mov-cli/config.toml`
+- **Linux/MacOS:** `~/.config/mov-cli/config.toml`
+
 ```toml
 [mov-cli.plugins]
 films = "package_name"
 ```
+
 
 2. Scraper away!
 ```sh

--- a/README.md
+++ b/README.md
@@ -66,8 +66,11 @@ mov-cli -e
 Alternatively, you may also edit by manually opening the config file in:
 
 - **Windows:** `%LocalAppData%/mov-cli/config.toml`
-- **Linux/MacOS:** `~/.config/mov-cli/config.toml`
-
+- **macOS:** `~/Library/Application Support/mov-cli/config.toml`
+- **Linux:** `~/.config/mov-cli/config.toml`
+- **iOS:** `~/Library/mov-cli/config.toml`
+- **Android:** `~/.config/mov-cli/config.toml`
+  
 ```toml
 [mov-cli.plugins]
 films = "package_name"


### PR DESCRIPTION
Can be useful when user bricks their config or when -e flag is not working properly. I know I've bricked mine once and I had to go looking where the config was 
