### PR TITLE
Add validation for scraper arguments in CLI

### DIFF
--- a/mov_cli/cli/__main__.py
+++ b/mov_cli/cli/__main__.py
@@ -14,7 +14,7 @@ from .search import search
 from .ui import welcome_msg
 from .episode import handle_episode
 from .plugins import show_all_plugins
-from .scraper import select_scraper, use_scraper, scrape, steal_scraper_args
+from .scraper import select_scraper, use_scraper, scrape, steal_scraper_args, validate_scraper_args
 from .configuration import open_config_file, set_cli_config
 
 from ..config import Config
@@ -97,9 +97,14 @@ def mov_cli(
     print(welcome_message)
 
     if query is not None:
-        scrape_options = steal_scraper_args(query) 
-        # This allows passing arguments to scrapers like this: 
-        # https://github.com/mov-cli/mov-cli-youtube/commit/b538d82745a743cd74a02530d6a3d476cd60b808#diff-4e5b064838aa74a5375265f4dfbd94024b655ee24a191290aacd3673abed921a
+        scrape_options, valid_scraper_args = steal_scraper_args(query) 
+
+        invalid_args = validate_scraper_args(scrape_options, valid_scraper_args)
+        if invalid_args:
+            mov_cli_logger.error(
+                f"Invalid scraper arguments: {', '.join(invalid_args)}. Available scraper arguments: {', '.join(valid_scraper_args)}"
+            )
+            return False
 
         query: str = " ".join(query)
 

--- a/mov_cli/cli/scraper.py
+++ b/mov_cli/cli/scraper.py
@@ -105,7 +105,7 @@ def select_scraper(plugins: Dict[str, str], scrapers: ScrapersConfigT, fzf_enabl
 
     return None
 
-def steal_scraper_args(query: List[str]) -> ScraperOptionsT:
+def steal_scraper_args(query: List[str]) -> Tuple[ScraperOptionsT, List[str]]:
     args_to_kidnap: List[str] = []
     arg_values_to_kidnap: List[str] = []
 
@@ -138,7 +138,9 @@ def steal_scraper_args(query: List[str]) -> ScraperOptionsT:
 
     mov_cli_logger.debug(f"Scraper args picked up on --> {scraper_options_args}")
 
-    return dict(scraper_options_args)
+    valid_scraper_args = [arg.replace("--", "").replace("-", "_") for arg in args_to_kidnap]
+
+    return dict(scraper_options_args), valid_scraper_args
 
 def get_scraper(scraper_id: str, plugins_data: PluginsDataT, user_defined_scrapers: ScrapersConfigT) -> Tuple[str, Type[Scraper] | Tuple[None, List[str]], ScraperOptionsT]:
     scraper_options = {}
@@ -172,3 +174,7 @@ def get_scraper(scraper_id: str, plugins_data: PluginsDataT, user_defined_scrape
                 return id, scraper, scraper_options
 
     return None, available_scrapers, scraper_options
+
+def validate_scraper_args(scrape_options: ScraperOptionsT, valid_scraper_args: List[str]) -> List[str]:
+    invalid_args = [arg for arg in scrape_options if arg not in valid_scraper_args]
+    return invalid_args


### PR DESCRIPTION
Related to #336

Add validation for CLI scraper arguments and provide error messages for invalid arguments.

* Modify `mov_cli/cli/__main__.py` to include validation for scraper arguments after extracting them using `steal_scraper_args`.
* If an invalid scraper argument is detected, exit the CLI and display an error message listing all available scraper arguments.
* Update `steal_scraper_args` function in `mov_cli/cli/scraper.py` to return a list of valid scraper arguments for validation purposes.
* Add a new function `validate_scraper_args` in `mov_cli/cli/scraper.py` to validate scraper arguments against the list of valid arguments.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/mov-cli/mov-cli/issues/336?shareId=79105984-14ea-4a67-87ce-2ba53b20d294).